### PR TITLE
Modificación del código para registrar la etiqueta del curso a las preguntas

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -96,6 +96,7 @@
         "nconf": "0.12.1",
         "nodebb-plugin-2factor": "7.5.3",
         "nodebb-plugin-composer-default": "10.2.36",
+        "nodebb-plugin-composer-question": "file:./nodebb-plugin-composer-question",
         "nodebb-plugin-dbsearch": "6.2.5",
         "nodebb-plugin-emoji": "5.1.15",
         "nodebb-plugin-emoji-android": "4.0.0",
@@ -156,7 +157,7 @@
         "@apidevtools/swagger-parser": "10.1.0",
         "@commitlint/cli": "19.3.0",
         "@commitlint/config-angular": "19.3.0",
-	"@types/async": "^3.2.16",
+        "@types/async": "^3.2.16",
         "@types/express": "^4.17.15",
         "@types/lodash": "^4.14.191",
         "@types/nconf": "^0.10.3",
@@ -178,7 +179,7 @@
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
         "smtp-server": "3.13.4",
-	"typescript": "^4.9.4"
+        "typescript": "^4.9.4"
     },
     "optionalDependencies": {
         "sass-embedded": "1.77.1"

--- a/nodebb-plugin-composer-question/static/lib/composer.js
+++ b/nodebb-plugin-composer-question/static/lib/composer.js
@@ -759,6 +759,7 @@ define('composer', [
 				cid: categoryList.getSelectedCid(),
 				tags: tags.getTags(post_uuid),
 				timestamp: scheduler.getTimestamp(),
+				courseTag: document.getElementById('course-tag-input') ? document.getElementById('course-tag-input').value : null,
 			};
 		} else if (action === 'posts.reply') {
 			route = `/topics/${postData.tid}`;

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -33,6 +33,7 @@ module.exports = function (Topics) {
 			lastposttime: 0,
 			postcount: 0,
 			viewcount: 0,
+			courseTag: data.courseTag
 		};
 
 		if (Array.isArray(data.tags) && data.tags.length) {


### PR DESCRIPTION
# Registro de la etiqueta de curso en la base de datos

## ¿Qué?
Se almacena una nueva clave "courseTag" para las preguntas en la base de datos.

## ¿Por qué?
Esta clave permitirá asociar cada pregunta con su respectivo curso, facilitando la categorización y recuperación de preguntas según el curso.

## ¿Cómo?
Se modifica el composer.js del plugin composer-question para capturar la etiqueta del curso desde un campo de entrada en el formulario y en src/topics/create.js se incluye la etiqueta del curso en los datos enviados al crear un tema para que posteriormente se almacene en la base de datos.

## Pruebas
- Se utilizó la extensión de "Redis for Vs Code" para visualizar los datos almacenados en la base de datos Redis y se verificó que se almacenaba correctamente el courseTag en los tópicos (preguntas).

## Capturas de pantalla (opcional)
![courseTag](https://github.com/user-attachments/assets/9fde36b9-9f62-4a08-ac7a-8b41988cb03c)


## ¿Algo más?
Más nada.

## Issues Relacionados
Resolves Issue #33 