### PR TITLE
Añade funcionalidad para marcar y desmarcar una respuesta como oficial

### DIFF
--- a/plugins/nodebb-plugin-questions-and-answers/library.js
+++ b/plugins/nodebb-plugin-questions-and-answers/library.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const Posts = require.main.require("./src/posts");
+const routeHelpers = require.main.require("./src/routes/helpers");
+
+const plugin = module.exports;
+
+plugin.init = async function (data) {};
+
+plugin.addApiRoute = async ({ router, middleware, helpers }) => {
+	const middlewares = [middleware.ensureLoggedIn];
+
+	// Adds API route to toggle official status of a post
+	routeHelpers.setupApiRoute(
+		router,
+		"post",
+		"/posts/official/:pid",
+		middlewares,
+		async (req, res) => {
+			const { body } = req;
+			await setOfficial(body);
+			helpers.formatApiResponse(200, res);
+		},
+	);
+};
+
+// Set the official status of a post
+const setOfficial = async (data) => {
+	const { pid, official } = data;
+	await Posts.setPostField(pid, "official", official);
+};

--- a/plugins/nodebb-plugin-questions-and-answers/plugin.json
+++ b/plugins/nodebb-plugin-questions-and-answers/plugin.json
@@ -2,5 +2,13 @@
   "id": "nodebb-plugin-questions-and-answers",
   "url": "nodebb-plugin-question-and-answers",
   "library": "library.js",
+  "hooks": [
+    { "hook": "static:app.load", "method": "init" },
+    {
+      "hook": "static:api.routes",
+      "method": "addApiRoute"
+    }
+  ],
+  "scripts": ["./static/lib/officialAnswer.js"],
   "templates": "./templates"
 }

--- a/plugins/nodebb-plugin-questions-and-answers/static/lib/officialAnswer.js
+++ b/plugins/nodebb-plugin-questions-and-answers/static/lib/officialAnswer.js
@@ -1,0 +1,30 @@
+import * as components from "components";
+import * as api from "api";
+
+const init = () => {
+	markAsOfficial();
+	unmarkAsOfficial();
+};
+
+const markAsOfficial = () => {
+	const buttons = components.get("post/markOfficial");
+	toggleOfficial(buttons, true);
+}
+
+const unmarkAsOfficial = () => {
+	const buttons = components.get("post/unmarkOfficial");
+	toggleOfficial(buttons, false);
+}
+
+const toggleOfficial = (buttons, officialStatus) => {
+	buttons.each(async function () {
+		const button = $(this);
+		const pid = button.parents("[data-pid]").data("pid");
+		const editedData = { pid, official: officialStatus };
+		button.on("click", async () => {
+			await api.post(`/plugins/posts/official/${pid}`, editedData);
+		});
+	});
+};
+
+init();

--- a/plugins/nodebb-plugin-questions-and-answers/static/lib/officialAnswer.js
+++ b/plugins/nodebb-plugin-questions-and-answers/static/lib/officialAnswer.js
@@ -1,5 +1,6 @@
 import * as components from "components";
 import * as api from "api";
+import * as alerts from "alerts";
 
 const init = () => {
 	markAsOfficial();
@@ -9,20 +10,28 @@ const init = () => {
 const markAsOfficial = () => {
 	const buttons = components.get("post/markOfficial");
 	toggleOfficial(buttons, true);
-}
+};
 
 const unmarkAsOfficial = () => {
 	const buttons = components.get("post/unmarkOfficial");
 	toggleOfficial(buttons, false);
-}
+};
 
 const toggleOfficial = (buttons, officialStatus) => {
 	buttons.each(async function () {
 		const button = $(this);
 		const pid = button.parents("[data-pid]").data("pid");
 		const editedData = { pid, official: officialStatus };
-		button.on("click", async () => {
-			await api.post(`/plugins/posts/official/${pid}`, editedData);
+		button.on("click", function () {
+			api.post(`/plugins/posts/official/${pid}`, editedData, function (err) {
+				if (err) {
+					if (!app.user.uid) {
+						ajaxify.go("login");
+						return;
+					}
+					return alerts.error(err);
+				}
+			});
 		});
 	});
 };

--- a/plugins/nodebb-plugin-questions-and-answers/templates/partials/topic/post.tpl
+++ b/plugins/nodebb-plugin-questions-and-answers/templates/partials/topic/post.tpl
@@ -1,0 +1,130 @@
+{{{ if (!./index && widgets.mainpost-header.length) }}}
+<div data-widget-area="mainpost-header">
+	{{{ each widgets.mainpost-header }}}
+	{widgets.mainpost-header.html}
+	{{{ end }}}
+</div>
+{{{ end }}}
+<div class="d-flex align-items-start gap-3">
+	<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
+		<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
+			{buildAvatar(posts.user, "48px", true, "", "user/picture")}
+			<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
+		</a>
+	</div>
+	<div class="post-container d-flex flex-grow-1 flex-column w-100" style="min-width:0;">
+		<div class="d-flex align-items-center gap-1 flex-wrap w-100 post-header mt-1" itemprop="author" itemscope itemtype="https://schema.org/Person">
+			<meta itemprop="name" content="{./user.username}">
+			{{{ if ./user.userslug }}}<meta itemprop="url" content="{config.relative_path}/user/{./user.userslug}">{{{ end }}}
+
+			<div class="bg-body d-sm-none">
+				<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
+					{buildAvatar(posts.user, "20px", true, "", "user/picture")}
+					<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
+				</a>
+			</div>
+
+			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+
+			{{{ each posts.user.selectedGroups }}}
+			{{{ if posts.user.selectedGroups.slug }}}
+			<!-- IMPORT partials/groups/badge.tpl -->
+			{{{ end }}}
+			{{{ end }}}
+
+			{{{ if posts.user.banned }}}
+			<span class="badge bg-danger rounded-1">[[user:banned]]</span>
+			{{{ end }}}
+
+			<div class="d-flex gap-1 align-items-center">
+				<span class="text-muted">{generateWroteReplied(@value, config.timeagoCutoff)}</span>
+
+				<i component="post/edit-indicator" class="fa fa-edit text-muted{{{ if privileges.posts:history }}} pointer{{{ end }}} edit-icon {{{ if !posts.editor.username }}}hidden{{{ end }}}" title="[[global:edited-timestamp, {isoTimeToLocaleString(./editedISO, config.userLang)}]]"></i>
+				<span data-editor="{posts.editor.userslug}" component="post/editor" class="visually-hidden">[[global:last-edited-by, {posts.editor.username}]] <span class="timeago" title="{isoTimeToLocaleString(posts.editedISO, config.userLang)}"></span></span>
+			</div>
+
+			{{{ if posts.user.custom_profile_info.length }}}
+			<div>
+				<span>
+					&#124;
+					{{{ each posts.user.custom_profile_info }}}
+					{posts.user.custom_profile_info.content}
+					{{{ end }}}
+				</span>
+			</div>
+			{{{ end }}}
+			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
+				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
+				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
+			</div>
+		</div>
+
+		<div class="content mt-2 text-break" component="post/content" itemprop="text">
+			{posts.content}
+		</div>
+	</div>
+</div>
+
+<div component="post/footer" class="post-footer border-bottom pb-2">
+	{{{ if posts.user.signature }}}
+	<div component="post/signature" data-uid="{posts.user.uid}" class="text-xs text-muted mt-2">{posts.user.signature}</div>
+	{{{ end }}}
+
+	<div class="d-flex">
+		{{{ if !hideReplies }}}
+		<a component="post/reply-count" data-target-component="post/replies/container" href="#" class="d-flex gap-2 align-items-center mt-2 btn-ghost ff-secondary border rounded-1 p-1 text-muted text-decoration-none text-xs {{{ if (!./replies || shouldHideReplyContainer(@value)) }}}hidden{{{ end }}}">
+			<span component="post/reply-count/avatars" class="d-flex gap-1 {{{ if posts.replies.hasMore }}}hasMore{{{ end }}}">
+				{{{each posts.replies.users}}}
+				<span>{buildAvatar(posts.replies.users, "20px", true, "avatar-tooltip")}</span>
+				{{{end}}}
+				{{{ if posts.replies.hasMore}}}
+				<span><i class="fa fa-ellipsis"></i></span>
+				{{{ end }}}
+			</span>
+
+			<span class="ms-2 replies-count fw-semibold" component="post/reply-count/text" data-replies="{posts.replies.count}">{posts.replies.text}</span>
+			<span class="ms-2 replies-last hidden-xs fw-semibold">[[topic:last-reply-time]] <span class="timeago" title="{posts.replies.timestampISO}"></span></span>
+
+			<i class="fa fa-fw fa-chevron-down" component="post/replies/open"></i>
+		</a>
+		{{{ end }}}
+	</div>
+
+	<div component="post/replies/container" class="my-2 col-11 border rounded-1 p-3 hidden-empty"></div>
+
+	<div component="post/actions" class="d-flex justify-content-end gap-1 post-tools">
+		<!-- IMPORT partials/topic/reactions.tpl -->
+		<a component="post/reply" href="#" class="btn-ghost-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:reply]]"><i class="fa fa-fw fa-reply text-primary"></i></a>
+		<a component="post/quote" href="#" class="btn-ghost-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:quote]]"><i class="fa fa-fw fa-quote-right text-primary"></i></a>
+		<a component="post/markOfficial" href="#" class="btn-ghost-sm {{{ if ((posts.index == 0) || (posts.official == "true")) }}}hidden{{{ end }}}" title="Mark as official answer"><i class="fa fa-fw fa-circle-check text-primary"></i></a>
+		<a component="post/unmarkOfficial" href="#" class="btn-ghost-sm {{{ if ((posts.index == 0) || (posts.official != "true")) }}}hidden{{{ end }}}" title="Unmark as official answer"><i class="fa fa-fw fa-circle-xmark text-danger"></i></a>
+
+		{{{ if !reputation:disabled }}}
+		<div class="d-flex votes align-items-center">
+			<a component="post/upvote" href="#" class="btn-ghost-sm{{{ if posts.upvoted }}} upvoted{{{ end }}}" title="[[topic:upvote-post]]">
+				<i class="fa fa-fw fa-chevron-up text-primary"></i>
+			</a>
+
+			<meta itemprop="upvoteCount" content="{posts.upvotes}">
+			<meta itemprop="downvoteCount" content="{posts.downvotes}">
+			<a href="#" class="px-2 mx-1 btn-ghost-sm" component="post/vote-count" data-votes="{posts.votes}" title="[[global:voters]]">{posts.votes}</a>
+
+			{{{ if !downvote:disabled }}}
+			<a component="post/downvote" href="#" class="btn-ghost-sm{{{ if posts.downvoted }}} downvoted{{{ end }}}" title="[[topic:downvote-post]]">
+				<i class="fa fa-fw fa-chevron-down text-primary"></i>
+			</a>
+			{{{ end }}}
+		</div>
+		{{{ end }}}
+
+		<!-- IMPORT partials/topic/post-menu.tpl -->
+	</div>
+</div>
+{{{ if (!./index && widgets.mainpost-footer.length) }}}
+<div data-widget-area="mainpost-footer">
+	{{{ each widgets.mainpost-footer }}}
+	{widgets.mainpost-footer.html}
+	{{{ end }}}
+</div>
+{{{ end }}}
+

--- a/plugins/nodebb-plugin-questions-and-answers/templates/partials/topic/post.tpl
+++ b/plugins/nodebb-plugin-questions-and-answers/templates/partials/topic/post.tpl
@@ -13,6 +13,13 @@
 		</a>
 	</div>
 	<div class="post-container d-flex flex-grow-1 flex-column w-100" style="min-width:0;">
+    {{{ if (posts.official == "true") }}}
+      <div class="bg-body d-flex gap-1 text-primary">
+        <i class="fa fa-check"></i>
+        <p class="post-header fw-bold">Answer marked as official</p>
+      </div>
+    {{{ end }}}
+
 		<div class="d-flex align-items-center gap-1 flex-wrap w-100 post-header mt-1" itemprop="author" itemscope itemtype="https://schema.org/Person">
 			<meta itemprop="name" content="{./user.username}">
 			{{{ if ./user.userslug }}}<meta itemprop="url" content="{config.relative_path}/user/{./user.userslug}">{{{ end }}}


### PR DESCRIPTION
## Descripción
Este PR añade la funcionalidad para marcar un post de algún tópico como oficial. Además, si un post ha sido marcado como oficial entonces podrá ser desmarcado como lo mismo. Así mismo, muestra un pequeño mensaje para denotar un post oficial.

Post oficial:
![image](https://github.com/user-attachments/assets/7c456fc8-551f-4dde-8781-42b55ae7a8d5).

## Implementación
Añade una nueva ruta en los endpoints de la API para modificar el atributo "official" de un post. Añade la funcionalidad a nivel del cliente para llamar a esa nueva ruta y cambiar el estatus oficial del post.

Las modificaciones ocurren dentro del plugin "questions-and-answers".

Cierra los issues:  #18 y #19.

Cierra parcialmente los issues: #17 y #20 a falta de que se añada el rol de profesor a un usuario.