### PR TITLE
Marcado de respuesta oficial solo para profesores

### DIFF
--- a/plugins/nodebb-plugin-questions-and-answers/library.js
+++ b/plugins/nodebb-plugin-questions-and-answers/library.js
@@ -1,15 +1,15 @@
-"use strict";
+'use strict';
 
-const Posts = require.main.require("./src/posts");
-const Topics = require.main.require("./src/topics");
-const routeHelpers = require.main.require("./src/routes/helpers");
+const Posts = require.main.require('./src/posts');
+const Topics = require.main.require('./src/topics');
+const routeHelpers = require.main.require('./src/routes/helpers');
 
 const plugin = module.exports;
 
 // Set the official status of a post
 const setOfficial = async (data) => {
 	const { pid, official } = data;
-	await Posts.setPostField(pid, "official", official);
+	await Posts.setPostField(pid, 'official', official);
 
 	// Notify topic followers
 	if (official) {
@@ -20,8 +20,8 @@ const setOfficial = async (data) => {
 			topic,
 		};
 		await Topics.notifyFollowers(notificationData, null, {
-			type: "new-reply",
-			bodyShort: "Answer marked as official",
+			type: 'new-reply',
+			bodyShort: 'Answer marked as official',
 			nid: `official_answer:tid:${notificationData.topic.tid}:pid:${notificationData.pid}`,
 			mergeId: `notifications:user-posted-to|${notificationData.topic.tid}`,
 		});
@@ -34,8 +34,8 @@ plugin.addApiRoute = async ({ router, middleware, helpers }) => {
 	// Adds API route to toggle official status of a post
 	routeHelpers.setupApiRoute(
 		router,
-		"post",
-		"/posts/official/:pid",
+		'post',
+		'/posts/official/:pid',
 		middlewares,
 		async (req, res) => {
 			const { body } = req;
@@ -49,4 +49,4 @@ plugin.addUserRole = async ({ uids, whitelist }) => {
 	whitelist.push('role');
 
 	return { uids, whitelist };
-}
+};

--- a/plugins/nodebb-plugin-questions-and-answers/library.js
+++ b/plugins/nodebb-plugin-questions-and-answers/library.js
@@ -44,3 +44,9 @@ plugin.addApiRoute = async ({ router, middleware, helpers }) => {
 		},
 	);
 };
+
+plugin.addUserRole = async ({ uids, whitelist }) => {
+	whitelist.push('role');
+
+	return { uids, whitelist };
+}

--- a/plugins/nodebb-plugin-questions-and-answers/plugin.json
+++ b/plugins/nodebb-plugin-questions-and-answers/plugin.json
@@ -6,7 +6,11 @@
 		{
 			"hook": "static:api.routes",
 			"method": "addApiRoute"
-		}
+		},
+    {
+      "hook": "filter:user.whitelistFields",
+      "method": "addUserRole"
+    }
 	],
 	"scripts": [
 		"./static/lib/officialAnswer.js",

--- a/plugins/nodebb-plugin-questions-and-answers/templates/partials/topic/post.tpl
+++ b/plugins/nodebb-plugin-questions-and-answers/templates/partials/topic/post.tpl
@@ -103,8 +103,10 @@
 		<!-- IMPORT partials/topic/reactions.tpl -->
 		<a component="post/reply" href="#" class="btn-ghost-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:reply]]"><i class="fa fa-fw fa-reply text-primary"></i></a>
 		<a component="post/quote" href="#" class="btn-ghost-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:quote]]"><i class="fa fa-fw fa-quote-right text-primary"></i></a>
-		<a component="post/markOfficial" href="#" class="btn-ghost-sm {{{ if ((posts.index == 0) || (posts.official == "true")) }}}hidden{{{ end }}}" title="Mark as official answer"><i class="fa fa-fw fa-circle-check text-primary"></i></a>
-		<a component="post/unmarkOfficial" href="#" class="btn-ghost-sm {{{ if ((posts.index == 0) || (posts.official != "true")) }}}hidden{{{ end }}}" title="Unmark as official answer"><i class="fa fa-fw fa-circle-xmark text-danger"></i></a>
+    {{{ if (loggedInUser.role == "Professor") }}}
+      <a component="post/markOfficial" href="#" class="btn-ghost-sm {{{ if ((posts.index == 0) || (posts.official == "true")) }}}hidden{{{ end }}}" title="Mark as official answer"><i class="fa fa-fw fa-circle-check text-primary"></i></a>
+      <a component="post/unmarkOfficial" href="#" class="btn-ghost-sm {{{ if ((posts.index == 0) || (posts.official != "true")) }}}hidden{{{ end }}}" title="Unmark as official answer"><i class="fa fa-fw fa-circle-xmark text-danger"></i></a>
+    {{{ end }}}
 
 		{{{ if !reputation:disabled }}}
 		<div class="d-flex votes align-items-center">


### PR DESCRIPTION
Este PR añade el renderizado condicional del botón de marcado de respuestas como oficiales. Este botón solo será visible para aquellos usuarios que tengan el rol de "Professor".

Cierra: #54 