### PR TITLE
Validaciones para el input de ID al registrar un estudiante

### DIFF
--- a/src/user/create.js
+++ b/src/user/create.js
@@ -157,6 +157,21 @@ module.exports = function (User) {
 				throw new Error('[[error:email-taken]]');
 			}
 		}
+
+		if (userData.role) {
+			if(userData.role === "Student"){
+				if (!userData.studentID) {
+					throw new Error("Invalid ID value, can't be empty");
+				}
+			}
+		}
+
+		if(userData.studentID){
+			const regex = /^\d{2}-\d{5}$/;
+			if (!regex.test(userData.studentID)) {
+				throw new Error('Invalid format for ID: 01-23456');
+			}
+		}
 	};
 
 	User.isPasswordValid = function (password, minStrength) {


### PR DESCRIPTION
Se agregaron las siguientes validaciones al input de ID:

El campo debe no estar vacío
El contenido del campo debe tener un formato XX-XXXXX, donde las X's deben ser numeros